### PR TITLE
Link screenshot to absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This is a [Swagger UI] plugin which renders the [contracts] of your operations (
 [Swagger UI]: https://swagger.io/tools/swagger-ui/
 [contracts]: https://en.wikipedia.org/wiki/Design_by_contract
 
-![screenshot of the plugin](screenshot.png)
+![screenshot of the plugin](
+https://raw.githubusercontent.com/mristin/swagger-ui-plugin-contracts/main/screenshot.png
+)
 
 # Usage
 


### PR DESCRIPTION
This is necessary so that the screenshot can be displayed on other sites
outside of GitHub.