### PR TITLE
Specify `prepublishOnly` script

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           node-version: 15.x
       - run: npm ci
-      - run: npm run check
+      - run: npm run prepublishOnly
 

--- a/.github/workflows/check-push-to-main.yml
+++ b/.github/workflows/check-push-to-main.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           node-version: 15.x
       - run: npm ci
-      - run: npm run check
+      - run: npm run prepublishOnly

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "prepare_manual_test": "copyfiles --flat build/index.js manual_test/",
     "serve_manual_test": "serve manual_test",
     "fix": "prettier --write src/ && eslint --fix src/**.js",
-    "check": "prettier --check src/ && eslint src/**.js && npm run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "check": "prettier --check src/ && eslint src/**.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublishOnly": "npm run check && npm run build"
   },
   "directories": {
     "build": "build"


### PR DESCRIPTION
This patch introduces the npm run script `prepublishOnly` so that the
package is *actually* built before publishing.

This was a mistake which slipped in during the release 0.0.1.